### PR TITLE
pref: Improve Projects Page Load Performance removing the await from useFetch

### DIFF
--- a/pages/projects.vue
+++ b/pages/projects.vue
@@ -18,7 +18,7 @@ useHead({
   ],
 })
 
-const { data } = await useFetch('/api/repos')
+const { data } = useFetch('/api/repos')
 </script>
 
 <template>


### PR DESCRIPTION
This PR addresses the issue of slow page loads and blocked navigation by removing `await` from `useFetch` on the projects page. This change improves the initial page load performance and enabling immediate navigation between pages.

### Changes Made

Removed `await` from `useFetch` calls in the following component/page:

Projects.vue

### Related Issues
Closes #62 

### Notes
This change may require updates to the project's loading states. I'm happy to make these updates if desired.